### PR TITLE
Add support for TravisCI runs on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+os: osx
+osx_image: xcode9.4
+language: objective-c
+
+install:
+  - sudo easy_install pip
+  - sudo pip install ansible
+
+script:
+  # Check syntax
+  - ansible-playbook --syntax-check playbook.yml
+
+  # Execute playbook (with 20 minute extension)
+  - travis_wait ansible-playbook playbook.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # prov
 
+[![Travis (.com)](https://img.shields.io/travis/com/MinnSoe/prov.svg?style=flat-square)](https://travis-ci.com/MinnSoe/prov)
+
 This repository is used to provision my environment using Ansible playbooks.
 
 `dotfiles` are stored in the MinnSoe/dotfiles repository. 


### PR DESCRIPTION
This PR adds initial support for testing the provisioning Ansible playbook. The first step is used to check for syntax errors, followed by a full run of the main playbook. This PR also adds the build status badge into the README.