### PR TITLE
Add minimal zsh config and support for user zsh dotfiles

### DIFF
--- a/roles/zsh/defaults/main.yml
+++ b/roles/zsh/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 
 zsh_user: '{{ ansible_user_id }}'
+zsh_user_home: '{{ ansible_env.HOME }}'
 zsh_homebrew_path: '/usr/local/bin/zsh'
 zsh_antigen_path: '{{ ansible_env.HOME }}/.zsh/antigen'
+zsh_antigen_directory: '.zsh/antigen'
+zsh_should_use_dotfiles: false
+zsh_dotfiles_location: '{{ ansible_env.HOME }}/dotfiles'

--- a/roles/zsh/tasks/configure.yml
+++ b/roles/zsh/tasks/configure.yml
@@ -1,0 +1,19 @@
+---
+- name: Create .zshrc file if it does not exist
+  copy:
+    content: ''
+    force: false
+    dest: '{{ ansible_env.HOME }}/.zshrc'
+    owner: '{{ zsh_user }}'
+    mode: 0644
+
+- name: Ensure antigen is sourced in .zshrc
+  lineinfile:
+    path: '{{ ansible_env.HOME }}/.zshrc'
+    line: 'source {{ zsh_antigen_path }}/antigen.zsh'
+
+- name: Ensure antigen is applied in .zshrc after configuring
+  lineinfile:
+    path: '{{ ansible_env.HOME }}/.zshrc'
+    insertafter: 'antigen'
+    line: 'antigen apply'

--- a/roles/zsh/tasks/configure.yml
+++ b/roles/zsh/tasks/configure.yml
@@ -1,4 +1,8 @@
 ---
+- name: Link user provided zsh configuration
+  command: 'stow -d {{ zsh_dotfiles_location }} -t {{ zsh_user_home }} zsh'
+  when: zsh_should_use_dotfiles
+
 - name: Create .zshrc file if it does not exist
   copy:
     content: ''
@@ -10,7 +14,7 @@
 - name: Ensure antigen is sourced in .zshrc
   lineinfile:
     path: '{{ ansible_env.HOME }}/.zshrc'
-    line: 'source {{ zsh_antigen_path }}/antigen.zsh'
+    line: 'source $HOME/{{ zsh_antigen_directory }}/antigen.zsh'
 
 - name: Ensure antigen is applied in .zshrc after configuring
   lineinfile:

--- a/roles/zsh/tasks/install.yml
+++ b/roles/zsh/tasks/install.yml
@@ -6,6 +6,7 @@
   with_items:
     - zsh
     - git
+    - stow
 
 - name: Set zsh path to system zsh
   command: which zsh

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -5,5 +5,7 @@
     - install
 
 - import_tasks: configure.yml
+  vars:
+    zsh_should_use_dotfiles: true
   tags:
     - configure

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -3,3 +3,7 @@
   tags:
     - zsh
     - install
+
+- import_tasks: configure.yml
+  tags:
+    - configure


### PR DESCRIPTION
This PR provides the minimum setup required to use `antigen` with `zsh`. Support is also provided for using user supplied configuration by triggering GNU Stow when `zsh_should_use_dotfiles` is `true`.