### PR TITLE
Add license section in the README file [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 This repository is used to provision my environment using Ansible playbooks.
 
 `dotfiles` are stored in the MinnSoe/dotfiles repository. 
+
+## License
+
+Copyright (c) 2018 Minn Soe under The MIT License (MIT).
+A copy of the license is provided in the [LICENSE](./LICENSE) file.


### PR DESCRIPTION
The README serves as the first piece of documentation and thus it should have a clear section on licensing. This PR adds a license section.